### PR TITLE
security: update requests and hash generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -200,7 +200,7 @@ def _save_history(mode: str) -> None:
         return
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
-    key = hashlib.sha1(
+    key = hashlib.sha256(
         (st.session_state.detection_script + "\n--\n" + st.session_state.remediation_script).encode(
             "utf-8"
         )
@@ -553,7 +553,7 @@ with col_a:
                 )
                 if item.reasons:
                     st.caption("Reasons: " + ", ".join(item.reasons))
-                select_key = hashlib.sha1(project.name.encode("utf-8")).hexdigest()[:8]
+                select_key = hashlib.sha256(project.name.encode("utf-8")).hexdigest()[:8]
                 if st.button(f"Select: {project.name}", key=f"community_select_{select_key}", use_container_width=True):
                     detection_file = project.detection_files[0] if project.detection_files else ""
                     remediation_file = project.remediation_files[0] if project.remediation_files else ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit==1.54.0
 azure-identity==1.25.2
 openai==2.21.0
-requests==2.32.5
+requests==2.34.2


### PR DESCRIPTION
## Summary
- update requests from 2.32.5 to 2.34.2 to clear the reported advisory
- replace SHA1-derived local IDs with SHA256-derived IDs

## Verification
- `pip-audit -r requirements.txt -f columns --progress-spinner off`
- `bandit -r . -q -f json -x ./.venv,./venv,./__pycache__` has no HIGH/MEDIUM findings
- `python3 -m py_compile app.py modules/*.py`
- `git diff --check`